### PR TITLE
Refactor: Rename 'Contributions' nav link to 'Roles'

### DIFF
--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
         <ul>
           <li><a href="#home">Home</a></li>
           <li><a href="#about">About</a></li>
-          <li><a href="#contributions">Contributions</a></li>
+          <li><a href="#contributions">Roles</a></li>
           <li><a href="#videos">Videos</a></li>
           <li><a href="#gallery">Gallery</a></li>
           <li><a href="#contact">Contact</a></li>
@@ -250,7 +250,7 @@
         <ul>
           <li><a href="#home">Home</a></li>
           <li><a href="#about">About</a></li>
-          <li><a href="#contributions">Contributions</a></li>
+          <li><a href="#contributions">Roles</a></li>
           <li><a href="#videos">Videos</a></li>
           <li><a href="#gallery">Gallery</a></li>
           <li><a href="#contact">Contact</a></li>


### PR DESCRIPTION
Updated the text for the navigation menu item that links to the 'Leadership Roles' section (id still #contributions) from 'Contributions' to 'Roles' in both desktop and mobile menus.