### PR TITLE
Feat: Create dedicated 'Audio' section with H2 heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,7 +275,7 @@
     }
 
     /* Audio Player */
-    #videos .audio-wrapper {
+    #audio .audio-wrapper { /* Changed from #videos to #audio */
       max-width: 600px;
       margin: 2rem auto; /* For centering the block and vertical margin */
       padding: 1rem;
@@ -284,7 +284,7 @@
       box-shadow: 0 2px 4px rgba(0,0,0,0.05);
       box-sizing: border-box; /* Ensures padding is included within the max-width */
     }
-    #videos .audio-wrapper iframe {
+    #audio .audio-wrapper iframe { /* Changed from #videos to #audio */
       width: 100%; /* Takes full width of padded parent */
       height: 166px;
       border: none;
@@ -507,6 +507,14 @@
         <div class="swiper-button-next"></div>
         <div class="swiper-button-prev"></div>
       </div>
+      <!-- audio-wrapper was here, now moved to its own section -->
+    </div>
+  </section>
+
+  <!-- Audio Section -->
+  <section id="audio">
+    <div class="section-content container">
+      <h2>Audio</h2>
       <div class="audio-wrapper" id="audio-player-content">
         <iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay"
           src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com/iskconbangalore/sets/amitasana-dasa"></iframe>


### PR DESCRIPTION
- Restructured page content to create a new, distinct <section id="audio">.
- Moved the Soundcloud player (div.audio-wrapper#audio-player-content) from the 'Videos' section into this new 'Audio' section.
- Added an <h2>Audio</h2> heading to the new section, styled consistently with other main section titles (Videos, Gallery).
- Updated CSS selectors for .audio-wrapper and its iframe to reflect their new parent section (#audio instead of #videos).
- Navigation links in the 'Media' dropdown remain correct and functional, pointing to the appropriate sections/content blocks.